### PR TITLE
Feature/thunderapi

### DIFF
--- a/src/features/thunder/api/thunderApi.ts
+++ b/src/features/thunder/api/thunderApi.ts
@@ -1,0 +1,105 @@
+import axios from 'axios';
+
+/**
+ * 번개모임 생성
+ */
+export const createThunder = async (data: {
+  title: string;
+  description: string;
+  category: string;
+  region: string;
+}): Promise<number> => {
+  const response = await axios.post('/api/thunders', data);
+  return response.data.thunder_id;
+};
+
+/**
+ * 번개모임 리스트 조회 (카테고리, 지역 기반)
+ */
+export const fetchThunderList = async (
+  category: string,
+  region: string,
+): Promise<
+  {
+    thunder_id: number;
+    title: string;
+    category: string;
+    region: string;
+  }[]
+> => {
+  const response = await axios.get(`/api/thunders?category=${category}&region=${region}`);
+  return response.data.thunders;
+};
+
+/**
+ * 번개모임 상세 조회
+ */
+export const fetchThunderDetail = async (
+  thunderId: number,
+): Promise<{
+  thunder_id: number;
+  title: string;
+  description: string;
+  category: string;
+  region: string;
+}> => {
+  const response = await axios.get(`/api/thunders/${thunderId}`);
+  return response.data;
+};
+
+/**
+ * 번개모임 가입
+ */
+export const joinThunder = async (thunderId: number): Promise<string> => {
+  const response = await axios.post(`/api/thunders/${thunderId}/join`);
+  return response.data.message;
+};
+
+/**
+ * 번개모임 탈퇴
+ */
+export const leaveThunder = async (thunderId: number): Promise<string> => {
+  const response = await axios.delete(`/api/thunders/${thunderId}/leave`);
+  return response.data.message;
+};
+
+/**
+ * 번개모임 삭제
+ */
+export const deleteThunder = async (thunderId: number): Promise<string> => {
+  const response = await axios.delete(`/api/thunders/${thunderId}`);
+  return response.data.message;
+};
+
+/**
+ * 번개모임 수정
+ */
+export const updateThunder = async (
+  thunderId: number,
+  data: { title: string; description: string },
+): Promise<string> => {
+  const response = await axios.put(`/api/thunders/${thunderId}`, data);
+  return response.data.message;
+};
+
+/**
+ * 번개모임 회원 관리 (가입 승인, 거절, 추방)
+ */
+export const manageThunderMember = async (
+  thunderId: number,
+  payload: { target_member_id: number; action: 'approve' | 'reject' | 'ban' },
+): Promise<string> => {
+  const response = await axios.post(`/api/thunders/${thunderId}/members/manage`, payload);
+  return response.data.message;
+};
+
+/**
+ * 번개모임 일정 등록
+ */
+export const createThunderEvent = async (
+  thunderId: number,
+  data: { title: string; description: string; eventDate: string },
+): Promise<number> => {
+  const response = await axios.post(`/api/thunders/${thunderId}/calendar/manage`, data);
+  return response.data.event_id;
+};

--- a/src/features/thunder/hooks/useThunder.ts
+++ b/src/features/thunder/hooks/useThunder.ts
@@ -1,0 +1,108 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+  createThunder,
+  fetchThunderDetail,
+  fetchThunderList,
+  joinThunder,
+  leaveThunder,
+  deleteThunder,
+  updateThunder,
+  manageThunderMember,
+  createThunderEvent,
+} from '../api/thunderApi';
+
+/**
+ * 번개모임 생성 훅
+ */
+export const useCreateThunder = () => {
+  return useMutation({ mutationFn: createThunder });
+};
+
+/**
+ * 번개모임 리스트 조회 훅 (카테고리 및 지역 기준)
+ */
+export const useThunderList = (category: string, region: string) => {
+  return useQuery({
+    queryKey: ['thunderList', category, region],
+    queryFn: () => fetchThunderList(category, region),
+  });
+};
+
+/**
+ * 번개모임 상세 조회 훅
+ */
+export const useThunderDetail = (thunderId: number) => {
+  return useQuery({
+    queryKey: ['thunderDetail', thunderId],
+    queryFn: () => fetchThunderDetail(thunderId),
+  });
+};
+
+/**
+ * 번개모임 참가 요청 훅
+ */
+export const useJoinThunder = () => {
+  return useMutation({ mutationFn: joinThunder });
+};
+
+/**
+ * 번개모임 탈퇴 훅
+ */
+export const useLeaveThunder = () => {
+  return useMutation({ mutationFn: leaveThunder });
+};
+
+/**
+ * 번개모임 삭제 훅
+ */
+export const useDeleteThunder = () => {
+  return useMutation({ mutationFn: deleteThunder });
+};
+
+/**
+ * 번개모임 수정 훅
+ * @example mutate({ thunderId, data: { title, description } })
+ */
+export const useUpdateThunder = () => {
+  return useMutation({
+    mutationFn: ({
+      thunderId,
+      data,
+    }: {
+      thunderId: number;
+      data: { title: string; description: string };
+    }) => updateThunder(thunderId, data),
+  });
+};
+
+/**
+ * 번개모임 회원 승인/거절/추방 훅
+ * @example mutate({ thunderId, payload: { target_member_id, action } })
+ */
+export const useManageThunderMember = () => {
+  return useMutation({
+    mutationFn: ({
+      thunderId,
+      payload,
+    }: {
+      thunderId: number;
+      payload: { target_member_id: number; action: 'approve' | 'reject' | 'ban' };
+    }) => manageThunderMember(thunderId, payload),
+  });
+};
+
+/**
+ * 번개모임 일정 등록 훅
+ * @example mutate({ thunderId, data: { date, content } })
+ */
+export const useCreateThunderEvent = () => {
+  return useMutation({
+    mutationFn: ({
+      thunderId,
+      data,
+    }: {
+      thunderId: number;
+      data: { title: string; description: string; eventDate: string };
+    }) => createThunderEvent(thunderId, data),
+  });
+};


### PR DESCRIPTION
## 🔥 번개모임 API 및 React Query 훅 구현

### 📌 주요 작업 내용
- `thunderApi.ts`에 번개모임 관련 API 정의
  - 번개 생성 / 조회 / 수정 / 삭제
  - 번개 참가 / 탈퇴
  - 회원 승인 / 거절 / 추방
  - 일정 등록

- `useThunder.ts` 커스텀 훅 구현 (React Query 기반)
  - `useCreateThunder`
  - `useThunderList`
  - `useThunderDetail`
  - `useJoinThunder`
  - `useLeaveThunder`
  - `useDeleteThunder`
  - `useUpdateThunder`
  - `useManageThunderMember`
  - `useCreateThunderEvent`

### ✨ 기타
- API 명세에 기반한 파라미터/응답 타입 정리
- mutation 인자 구조로 타입 에러 해결

---
