### PR TITLE
Chore/storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,5 +12,16 @@ const config: StorybookConfig = {
     name: '@storybook/react-vite',
     options: {},
   },
+  viteFinal: (config) => {
+    config.define = {
+      ...(config.define || {}),
+      process: {
+        env: {},
+        version: 'v22.11.0',
+      },
+    };
+    return config;
+  },
 };
+
 export default config;

--- a/src/common/components/ui/Buttons.tsx
+++ b/src/common/components/ui/Buttons.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import styled from '@emotion/styled/macro';
+import styled from '@emotion/styled';
 
 // 모달 열기 버튼
 interface ModalButtonProps {

--- a/src/features/club/components/ClubForm.tsx
+++ b/src/features/club/components/ClubForm.tsx
@@ -71,6 +71,9 @@ const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit }) => {
         <textarea value={description} onChange={(e) => setDescription(e.target.value)} />
       </div>
 
+      {/* 이미지 URL 입력 필드 추가 */}
+      {/* 실제로는 파일 업로드 기능을 구현해야 하지만, 여기서는 URL 입력으로 대체합니다. */}
+      {/* 이 부분은 나중에 수정 필요요.*/}
       <div>
         <label>이미지 URL</label>
         <input type="text" value={imageUrl} onChange={(e) => setImageUrl(e.target.value)} />

--- a/stories/BaseList.stories.tsx
+++ b/stories/BaseList.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import BaseList from '../src/common/components/ui/BaseList';
+import { MemoryRouter } from 'react-router-dom';
+
+// 기본 mock 데이터
+const sampleItems = [
+  { id: '1', name: '축구 동호회', imageUrl: 'https://via.placeholder.com/100x100' },
+  { id: '2', name: '등산 모임', imageUrl: 'https://via.placeholder.com/100x100' },
+  { id: '3', name: '스터디 클럽', imageUrl: 'https://via.placeholder.com/100x100' },
+];
+
+const meta: Meta<typeof BaseList> = {
+  title: 'Components/BaseList',
+  component: BaseList,
+  decorators: [
+    (Story) => (
+      // useNavigate 대응을 위해 Router Provider 필요
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof BaseList>;
+
+export const Default: Story = {
+  args: {
+    items: sampleItems,
+    routePrefix: '/club',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+    routePrefix: '/club',
+  },
+};

--- a/stories/ClubDetail.stories.tsx
+++ b/stories/ClubDetail.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ClubDetail from '../src/features/club/components/ClubDetail';
+
+const meta: Meta<typeof ClubDetail> = {
+  title: 'Club/ClubDetail',
+  component: ClubDetail,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ClubDetail>;
+
+// 샘플 데이터
+const admins = [
+  {
+    id: 'admin1',
+    name: '홍길동',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=Admin1',
+  },
+];
+
+const members = [
+  {
+    id: 'member1',
+    name: '김철수',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=Member1',
+  },
+  {
+    id: 'member2',
+    name: '이영희',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=Member2',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    imageUrl: 'https://via.placeholder.com/300x150?text=Club+Image',
+    name: 'React Study Club',
+    description: '이 모임은 리액트를 함께 공부하는 사람들의 모임입니다.',
+    admins,
+    members,
+  },
+};

--- a/stories/ClubForm.stories.tsx
+++ b/stories/ClubForm.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ClubForm from '../src/features/club/components/ClubForm';
+
+const meta: Meta<typeof ClubForm> = {
+  title: 'Club/ClubForm',
+  component: ClubForm,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ClubForm>;
+
+const sampleAdmins = [
+  {
+    id: 'admin1',
+    name: '홍길동',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=Admin',
+  },
+];
+
+const sampleMembers = [
+  {
+    id: 'm1',
+    name: '김철수',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=Member1',
+  },
+  {
+    id: 'm2',
+    name: '이영희',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=Member2',
+  },
+];
+
+export const CreateMode: Story = {
+  args: {
+    mode: 'create',
+    onSubmit: (data) => alert(`제출 데이터: ${JSON.stringify(data, null, 2)}`),
+  },
+};
+
+export const EditMode: Story = {
+  args: {
+    mode: 'edit',
+    initialData: {
+      name: 'React 모임',
+      description: '리액트를 공부하는 개발자 모임입니다.',
+      imageUrl: 'https://via.placeholder.com/300x150?text=Club',
+      adims: sampleAdmins,
+      members: sampleMembers,
+    },
+    onSubmit: (data) => alert(`수정된 데이터: ${JSON.stringify(data, null, 2)}`),
+  },
+};

--- a/stories/ClubMembers.stories.tsx
+++ b/stories/ClubMembers.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ClubMembers from '../src/features/club/components/ClubMembers';
+
+const meta: Meta<typeof ClubMembers> = {
+  title: 'Club/ClubMembers',
+  component: ClubMembers,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ClubMembers>;
+
+const sampleAdmins = [
+  { id: 'a1', name: '홍길동', profileImageUrl: 'https://via.placeholder.com/80x80?text=Admin' },
+];
+
+const sampleMembers = [
+  { id: 'm1', name: '김철수', profileImageUrl: 'https://via.placeholder.com/80x80?text=Member1' },
+  { id: 'm2', name: '이영희', profileImageUrl: 'https://via.placeholder.com/80x80?text=Member2' },
+];
+
+export const Default: Story = {
+  args: {
+    admins: sampleAdmins,
+    members: sampleMembers,
+  },
+};
+
+export const OnlyAdmins: Story = {
+  args: {
+    admins: sampleAdmins,
+    members: [],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    admins: [],
+    members: [],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '**[주의] 실제 운영상 이 상태는 발생하지 않아야 하며, 잘못된 사용 예입니다. admins는 필수입니다.',
+      },
+    },
+  },
+};

--- a/stories/ClubRequest.stories.tsx
+++ b/stories/ClubRequest.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ClubRequest from '../src/features/club/components/ClubRequest';
+
+const meta: Meta<typeof ClubRequest> = {
+  title: 'Club/ClubRequest',
+  component: ClubRequest,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ClubRequest>;
+
+const sampleUsers = [
+  {
+    id: 'user1',
+    name: '김하늘',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=User1',
+  },
+  {
+    id: 'user2',
+    name: '이바다',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=User2',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    pendingUsers: sampleUsers,
+    onApprove: (userId) => alert(`가입 승인됨: ${userId}`),
+  },
+};

--- a/stories/ThenderForm.stories.tsx
+++ b/stories/ThenderForm.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ThunderForm from '../src/features/thunder/components/ThunderForm';
+
+const meta: Meta<typeof ThunderForm> = {
+  title: 'Thunder/ThunderForm',
+  component: ThunderForm,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ThunderForm>;
+
+export const CreateMode: Story = {
+  args: {
+    mode: 'create',
+  },
+};
+
+export const EditMode: Story = {
+  args: {
+    mode: 'edit',
+    initialData: {
+      title: '밤마실 번개',
+      description: '야경 보러 남산 한 바퀴 돌아요 🌃',
+      region: { city: '서울', district: '중구' },
+      date: '2024-05-01',
+      hour: 20,
+      minute: 0,
+    },
+  },
+};

--- a/stories/ThunderDetail.stories.tsx
+++ b/stories/ThunderDetail.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ThunderDetail from '../src/features/thunder/components/ThunderDetail';
+
+const meta: Meta<typeof ThunderDetail> = {
+  title: 'Thunder/ThunderDetail',
+  component: ThunderDetail,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ThunderDetail>;
+
+const sampleMembers = [
+  {
+    memberId: 1,
+    nickname: '번개리더',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=Leader',
+    isAdmin: true,
+  },
+  {
+    memberId: 2,
+    nickname: '참가자1',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=User1',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    thunderId: 101,
+    title: '퇴근 후 맥주 한 잔 번개',
+    description: '강남역 근처에서 간단하게 맥주 한 잔 하실 분~ 🍻',
+    category: '술자리',
+    region: '강남역',
+    imageUrl: 'https://via.placeholder.com/300x150?text=Thunder',
+    dateTime: '2024-05-01 19:00',
+    location: '강남역 11번 출구 앞',
+    members: sampleMembers,
+  },
+};
+
+export const NoImageNoLocation: Story = {
+  args: {
+    thunderId: 102,
+    title: '조용히 산책 번개',
+    description: '반포 한강공원에서 조용히 걷고 이야기 나누는 모임입니다.',
+    category: '산책',
+    region: '서초구',
+    dateTime: '2024-05-03 10:00',
+    members: sampleMembers,
+  },
+};
+
+export const EmptyMembers: Story = {
+  args: {
+    thunderId: 103,
+    title: '영화 같이 보실 분!',
+    description: '용산 CGV에서 영화 볼 분 구합니다. 🎬',
+    category: '문화',
+    region: '용산',
+    imageUrl: 'https://via.placeholder.com/300x150?text=Movie+Thunder',
+    dateTime: '2024-05-07 18:30',
+    location: '용산 CGV',
+    members: [],
+  },
+};

--- a/stories/ThunderMembers.stories.tsx
+++ b/stories/ThunderMembers.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ThunderMembers from '../src/features/thunder/components/ThunderMembers';
+
+const meta: Meta<typeof ThunderMembers> = {
+  title: 'Thunder/ThunderMembers',
+  component: ThunderMembers,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ThunderMembers>;
+
+const sampleMembers = [
+  {
+    memberId: 1,
+    nickname: '리더짱',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=Admin',
+    isAdmin: true,
+  },
+  {
+    memberId: 2,
+    nickname: '참가자1',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=User1',
+  },
+  {
+    memberId: 3,
+    nickname: '참가자2',
+    profileImageUrl: 'https://via.placeholder.com/80x80?text=User2',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    members: sampleMembers,
+  },
+};
+
+export const WithBanButton: Story = {
+  args: {
+    members: sampleMembers,
+    onBanClick: (id) => alert(`멤버 ${id} 추방됨!`),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    members: [],
+  },
+};


### PR DESCRIPTION
## 📌 작업 내용
- Club 관련 컴포넌트 스토리 작성
  - ClubDetail
  - ClubMembers
  - ClubForm
  - ClubRequest

- Thunder 관련 컴포넌트 스토리 작성
  - ThunderDetail
  - ThunderForm
  - ThunderMembers

- 각 컴포넌트별 상태, 조건(props) 기반 variation 분리
  - 예: `mode=create|edit`, `members=[]`, `isAdmin` 등

## 🎯 작업 목적
- 개발/디자인 시 컴포넌트 시각화 및 동작 확인
- 추후 QA, 리팩토링, 신규 기능 개발 시 테스트 기반 확보
- 팀원 간 컴포넌트 구조 공유 및 빠른 피드백 환경 구축

## 🧪 테스트
- Storybook UI에서 각 스토리 정상 렌더링 확인
- 모달, 버튼 클릭 등 인터랙션 포함된 컴포넌트도 정상 동작

## 📝 기타 참고
- 추후 `onReject`, `submit`, `api 연결` 관련 리팩토링 예정

