### PR TITLE
Refactor/club

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
 import { ThemeProvider } from '@emotion/react';
+import { MemoryRouter } from 'react-router-dom';
 import GlobalStyle from '../src/common/style/GlobalStyle';
 import { theme } from '../src/common/style/theme.css';
 import type { Preview } from '@storybook/react';
@@ -16,13 +17,15 @@ const preview: Preview = {
   },
 };
 
-// ✅ 전역 스타일 + 테마 적용
+// ✅ 전역 스타일 + 테마 + 라우터 적용
 export const decorators = [
   (Story: React.FC) => (
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <Story />
-    </ThemeProvider>
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <Story />
+      </ThemeProvider>
+    </MemoryRouter>
   ),
 ];
 

--- a/src/common/components/ui/Modal.tsx
+++ b/src/common/components/ui/Modal.tsx
@@ -24,7 +24,8 @@ interface ModalProps {
   confirmText?: string;
   cancelText?: string;
   onConfirm?: (data?: any) => void;
-  onCancel?: () => void;
+  onCancel?: () => void; // "거절" 버튼 클릭 시 실행
+  onClose?: () => void; // 닫기(X), ESC 키 등 단순 닫기 처리용 (✅ 추가됨)
   errorText?: string;
   /** checkbox 모드일 때 외부에서 관리되는 선택값 */
   checked?: string[];
@@ -53,7 +54,8 @@ interface ModalProps {
  *   - title, description: 모달 제목과 설명 텍스트
  *   - confirmText, cancelText: 확인 및 취소 버튼 텍스트
  *   - onConfirm: 확인 버튼 클릭 시 실행할 콜백 (모드에 따라 전달되는 데이터 달라짐)
- *   - onCancel: 취소 버튼 클릭 시 실행할 콜백
+ *   - onCancel: 취소(거절) 버튼 클릭 시 실행할 콜백
+ *   - onClose: X 버튼 클릭 또는 ESC 입력 시 실행되는 닫기 콜백 (✅ 추가됨)
  *   - errorText: input 모드에서 입력값 하단에 표시할 에러 텍스트
  *
  * - checkbox 모드 전용:
@@ -76,6 +78,7 @@ const Modal: React.FC<ModalProps> = ({
   cancelText,
   onConfirm,
   onCancel,
+  onClose,
   errorText,
   checked = [],
   onCheckedChange,
@@ -91,18 +94,17 @@ const Modal: React.FC<ModalProps> = ({
     };
   }, [isOpen]);
 
-  // esc로 모달창 닫기
+  // ESC 키로 모달 닫기 (✅ onClose로 분리 처리)
   useEffect(() => {
-    if (!isOpen || !onCancel) return;
+    if (!isOpen || !onClose) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel();
+      if (e.key === 'Escape') onClose();
     };
-
     window.addEventListener('keydown', handleKeyDown);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [isOpen, onCancel]);
+  }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 
@@ -163,6 +165,7 @@ const Modal: React.FC<ModalProps> = ({
         )}
 
         {children && <div>{children}</div>}
+
         {(confirmText && onConfirm) || (cancelText && onCancel) ? (
           <div>
             {cancelText && onCancel && (
@@ -178,10 +181,10 @@ const Modal: React.FC<ModalProps> = ({
           </div>
         ) : null}
 
-        {/* 닫기 버튼 */}
-        {onCancel && (
+        {/* 닫기 버튼 (✅ onClose로 분리 처리) */}
+        {onClose && (
           <div>
-            <CloseModal onClick={onCancel} aria-label="모달 닫기">
+            <CloseModal onClick={onClose} aria-label="모달 닫기">
               ×
             </CloseModal>
           </div>

--- a/src/features/club/components/ClubForm.tsx
+++ b/src/features/club/components/ClubForm.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Modal from '../../../common/components/ui/Modal';
+import ButtonUnit from '../../../common/components/ui/Buttons';
 
 interface ClubMember {
   id: string;
@@ -17,19 +18,33 @@ interface ClubFormProps {
     members: ClubMember[];
   };
   onSubmit?: (data: { name: string; description: string; imageUrl: string }) => void;
+  onImageUpload?: (file: File) => Promise<string>; // 이미지 업로드 콜백
 }
-
 /**
  * ClubForm 컴포넌트
  *
- * 클럽 생성/수정 폼을 렌더링하는 컴포넌트
- * - mode: 'create' | 'edit'에 따라 입력 필드의 기본값이 다름
- * - 운영진/멤버 프로필은 직접 렌더링함
- * - 멤버 프로필 옆에는 추방 버튼이 있으며 클릭 시 확인 모달이 열림
- * - 하단 버튼 영역은 포함하지 않음
- * - name, description, imageUrl 값은 onSubmit을 통해 상위로 전달 가능
+ * 클럽 생성 또는 수정 시 사용하는 폼 컴포넌트입니다.
+ *
+ * - `mode`에 따라 `"create"` 또는 `"edit"` 모드로 동작합니다.
+ * - `"edit"` 모드일 경우, `initialData`를 통해 기존 데이터를 불러와 입력 필드에 초기화합니다.
+ * - 이미지 업로드는 외부에서 전달된 `onImageUpload` 콜백으로 처리하며, 업로드된 이미지 URL을 상태에 반영합니다.
+ * - 클럽 멤버는 운영진(`adims`)과 일반 멤버(`members`)로 구분되며,
+ *   일반 멤버는 "추방하기" 버튼을 통해 모달 확인 후 제거할 수 있습니다.
+ * - 등록/수정 완료 시 `onSubmit` 콜백이 호출되며, name, description, imageUrl을 포함한 데이터가 전달됩니다.
+ *
+ * @component
+ * @param {ClubFormProps} props - 클럽 폼 컴포넌트에 전달되는 props
+ * @param {'create' | 'edit'} props.mode - 생성 또는 수정 모드
+ * @param {Object} [props.initialData] - 수정 시 사용할 초기 데이터 (edit 모드에서만 사용)
+ * @param {string} props.initialData.name - 클럽명
+ * @param {string} props.initialData.description - 클럽 설명
+ * @param {string} props.initialData.imageUrl - 대표 이미지 URL
+ * @param {ClubMember[]} props.initialData.adims - 운영진 목록
+ * @param {ClubMember[]} props.initialData.members - 클럽 멤버 목록
+ * @param {(data: { name: string; description: string; imageUrl: string }) => void} [props.onSubmit] - 등록/수정 완료 시 실행되는 콜백
+ * @param {(file: File) => Promise<string>} [props.onImageUpload] - 이미지 업로드 콜백 (업로드 성공 시 이미지 URL 반환)
  */
-const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit }) => {
+const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit, onImageUpload }) => {
   const [name, setName] = useState(initialData?.name || '');
   const [description, setDescription] = useState(initialData?.description || '');
   const [imageUrl, setImageUrl] = useState(initialData?.imageUrl || '');
@@ -37,6 +52,24 @@ const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit }) => {
   const [members, setMembers] = useState<ClubMember[]>(initialData?.members || []);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !onImageUpload) return;
+
+    try {
+      const uploadedUrl = await onImageUpload(file);
+      setImageUrl(uploadedUrl);
+    } catch (err) {
+      console.error('이미지 업로드 실패:', err);
+    }
+  };
 
   const handleExpelClick = (userId: string) => {
     setSelectedUserId(userId);
@@ -66,17 +99,21 @@ const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit }) => {
         <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
       </div>
 
+      {/* ✅ 이미지 업로드 영역 */}
+      <div onClick={handleImageClick}>
+        {imageUrl ? <img src={imageUrl} alt="미리보기" /> : <div>이미지 넣기</div>}
+      </div>
+      <input
+        type="file"
+        accept="image/*"
+        style={{ display: 'none' }}
+        ref={fileInputRef}
+        onChange={handleImageUpload}
+      />
+
       <div>
         <label>모임 소개</label>
         <textarea value={description} onChange={(e) => setDescription(e.target.value)} />
-      </div>
-
-      {/* 이미지 URL 입력 필드 추가 */}
-      {/* 실제로는 파일 업로드 기능을 구현해야 하지만, 여기서는 URL 입력으로 대체합니다. */}
-      {/* 이 부분은 나중에 수정 필요요.*/}
-      <div>
-        <label>이미지 URL</label>
-        <input type="text" value={imageUrl} onChange={(e) => setImageUrl(e.target.value)} />
       </div>
 
       <div>
@@ -98,7 +135,9 @@ const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit }) => {
             <div key={member.id}>
               <img src={member.profileImageUrl} alt={member.name} />
               <span>{member.name}</span>
-              <button onClick={() => handleExpelClick(member.id)}>추방하기</button>
+              <ButtonUnit mode="text" onClick={() => handleExpelClick(member.id)}>
+                추방하기
+              </ButtonUnit>
             </div>
           ))}
         </div>
@@ -113,6 +152,13 @@ const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit }) => {
         onConfirm={handleConfirmExpel}
         onCancel={() => setIsModalOpen(false)}
       />
+
+      {/* ✅ 등록/수정 버튼 */}
+      <div>
+        <ButtonUnit mode="confirm" onClick={handleSubmit}>
+          {mode === 'edit' ? '수정 완료' : '등록'}
+        </ButtonUnit>
+      </div>
     </div>
   );
 };

--- a/src/features/club/components/ClubForm.tsx
+++ b/src/features/club/components/ClubForm.tsx
@@ -17,37 +17,15 @@ interface ClubFormProps {
     adims: ClubMember[];
     members: ClubMember[];
   };
-  onSubmit?: (data: { name: string; description: string; imageUrl: string }) => void;
-  onImageUpload?: (file: File) => Promise<string>; // 이미지 업로드 콜백
+  onSubmit?: (data: { name: string; description: string; image: File | null }) => void;
+  onImageUpload?: (file: File) => Promise<string>; // 이미지 업로드 콜백 (옵션으로 유지 가능)
 }
-/**
- * ClubForm 컴포넌트
- *
- * 클럽 생성 또는 수정 시 사용하는 폼 컴포넌트입니다.
- *
- * - `mode`에 따라 `"create"` 또는 `"edit"` 모드로 동작합니다.
- * - `"edit"` 모드일 경우, `initialData`를 통해 기존 데이터를 불러와 입력 필드에 초기화합니다.
- * - 이미지 업로드는 외부에서 전달된 `onImageUpload` 콜백으로 처리하며, 업로드된 이미지 URL을 상태에 반영합니다.
- * - 클럽 멤버는 운영진(`adims`)과 일반 멤버(`members`)로 구분되며,
- *   일반 멤버는 "추방하기" 버튼을 통해 모달 확인 후 제거할 수 있습니다.
- * - 등록/수정 완료 시 `onSubmit` 콜백이 호출되며, name, description, imageUrl을 포함한 데이터가 전달됩니다.
- *
- * @component
- * @param {ClubFormProps} props - 클럽 폼 컴포넌트에 전달되는 props
- * @param {'create' | 'edit'} props.mode - 생성 또는 수정 모드
- * @param {Object} [props.initialData] - 수정 시 사용할 초기 데이터 (edit 모드에서만 사용)
- * @param {string} props.initialData.name - 클럽명
- * @param {string} props.initialData.description - 클럽 설명
- * @param {string} props.initialData.imageUrl - 대표 이미지 URL
- * @param {ClubMember[]} props.initialData.adims - 운영진 목록
- * @param {ClubMember[]} props.initialData.members - 클럽 멤버 목록
- * @param {(data: { name: string; description: string; imageUrl: string }) => void} [props.onSubmit] - 등록/수정 완료 시 실행되는 콜백
- * @param {(file: File) => Promise<string>} [props.onImageUpload] - 이미지 업로드 콜백 (업로드 성공 시 이미지 URL 반환)
- */
-const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit, onImageUpload }) => {
+
+const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit }) => {
   const [name, setName] = useState(initialData?.name || '');
   const [description, setDescription] = useState(initialData?.description || '');
-  const [imageUrl, setImageUrl] = useState(initialData?.imageUrl || '');
+  const [image, setImage] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState(initialData?.imageUrl || '');
   const [adims] = useState<ClubMember[]>(initialData?.adims || []);
   const [members, setMembers] = useState<ClubMember[]>(initialData?.members || []);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
@@ -59,15 +37,11 @@ const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit, onImag
     fileInputRef.current?.click();
   };
 
-  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file || !onImageUpload) return;
-
-    try {
-      const uploadedUrl = await onImageUpload(file);
-      setImageUrl(uploadedUrl);
-    } catch (err) {
-      console.error('이미지 업로드 실패:', err);
+    if (file) {
+      setImage(file);
+      setPreviewUrl(URL.createObjectURL(file));
     }
   };
 
@@ -86,7 +60,7 @@ const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit, onImag
 
   const handleSubmit = () => {
     if (onSubmit) {
-      onSubmit({ name, description, imageUrl });
+      onSubmit({ name, description, image });
     }
   };
 
@@ -100,15 +74,15 @@ const ClubForm: React.FC<ClubFormProps> = ({ mode, initialData, onSubmit, onImag
       </div>
 
       {/* ✅ 이미지 업로드 영역 */}
-      <div onClick={handleImageClick}>
-        {imageUrl ? <img src={imageUrl} alt="미리보기" /> : <div>이미지 넣기</div>}
+      <div onClick={handleImageClick} style={{ cursor: 'pointer' }}>
+        {previewUrl ? <img src={previewUrl} alt="미리보기" /> : <div>이미지 넣기</div>}
       </div>
       <input
         type="file"
         accept="image/*"
         style={{ display: 'none' }}
         ref={fileInputRef}
-        onChange={handleImageUpload}
+        onChange={handleImageSelect}
       />
 
       <div>

--- a/src/features/club/components/ClubList.tsx
+++ b/src/features/club/components/ClubList.tsx
@@ -9,6 +9,7 @@ interface ClubItem {
 
 interface ClubListProps {
   items: ClubItem[];
+  routePrefix: string;
 }
 
 /**

--- a/src/features/club/components/ClubList.tsx
+++ b/src/features/club/components/ClubList.tsx
@@ -1,7 +1,32 @@
 import React from 'react';
+import BaseList from '../../../common/components/ui/BaseList';
 
-function ClubList() {
-  return <div>ClubList</div>;
+interface ClubItem {
+  id: string;
+  name: string;
+  imageUrl: string;
 }
+
+interface ClubListProps {
+  items: ClubItem[];
+}
+
+/**
+ * ClubList 컴포넌트
+ *
+ * 클럽 목록을 렌더링하는 프레젠테이셔널 컴포넌트입니다.
+ * - 상위 컴포넌트에서 클럽 데이터 배열을 props로 전달받아 화면에 리스트 형태로 표시합니다.
+ * - 각 클럽은 BaseList를 통해 카드 형태로 렌더링되며, 클릭 시 클럽 상세 페이지로 이동합니다.
+ * - 데이터가 비어 있을 경우 "클럽이 없습니다." 문구만 렌더링합니다.
+ *
+ * @component
+ * @param {ClubListProps} props - 클럽 리스트 렌더링에 필요한 props
+ * @param {ClubItem[]} props.items - 클럽 데이터 배열 (id, name, imageUrl 포함)
+ * @returns {JSX.Element} 클럽 목록 UI 또는 빈 안내 메시지
+ */
+const ClubList: React.FC<ClubListProps> = ({ items }) => {
+  if (items.length === 0) return <div>클럽이 없습니다.</div>;
+  return <BaseList items={items} routePrefix="/club" />;
+};
 
 export default ClubList;

--- a/src/features/club/components/ClubRequest.tsx
+++ b/src/features/club/components/ClubRequest.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Modal from '../../../common/components/ui/Modal';
-import { SubmitButton } from '../../../common/components/ui/Buttons';
+import ButtonUnit from '../../../common/components/ui/Buttons';
 
 interface ClubMember {
   id: string;
@@ -11,22 +11,24 @@ interface ClubMember {
 interface ClubRequestProps {
   pendingUsers: ClubMember[];
   onApprove: (userId: string) => void;
+  onReject?: (userId: string) => void; // ✅ 거절 콜백 추가
 }
 
 /**
  * ClubRequest 컴포넌트
  *
- * 클럽 가입 요청자 목록을 표시하고 가입 수락을 위한 모달을 띄운다.
+ * 클럽 가입 요청자 목록을 표시하고 가입 수락/거절을 위한 모달을 띄운다.
  * - 상위 컴포넌트에서 pendingUsers를 전달받아 렌더링함
  * - 각 유저 항목에는 가입 수락 버튼이 존재하고, 클릭 시 확인 모달이 표시됨
  * - 모달에서 '승인' 시 onApprove 콜백으로 유저 ID를 상위에 전달
- * - 리스트는 클럽 멤버스와 동일하게 상위에서 더보기 상태를 관리하고 전달
+ * - '거절' 시 onReject 콜백으로 유저 ID를 상위에 전달
+ * - 닫기(X) 또는 ESC 키는 단순히 모달만 닫힘
  *
  * @component
- * @param {ClubRequestProps} props - 가입 대기자 리스트와 승인 콜백
+ * @param {ClubRequestProps} props - 가입 대기자 리스트와 승인/거절 콜백
  * @returns {JSX.Element} 가입 요청자 리스트 UI
  */
-const ClubRequest: React.FC<ClubRequestProps> = ({ pendingUsers, onApprove }) => {
+const ClubRequest: React.FC<ClubRequestProps> = ({ pendingUsers, onApprove, onReject }) => {
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -37,6 +39,15 @@ const ClubRequest: React.FC<ClubRequestProps> = ({ pendingUsers, onApprove }) =>
 
   const handleConfirm = () => {
     if (selectedUserId) onApprove(selectedUserId);
+    closeModal();
+  };
+
+  const handleReject = () => {
+    if (selectedUserId && onReject) onReject(selectedUserId);
+    closeModal();
+  };
+
+  const closeModal = () => {
     setIsModalOpen(false);
     setSelectedUserId(null);
   };
@@ -49,7 +60,9 @@ const ClubRequest: React.FC<ClubRequestProps> = ({ pendingUsers, onApprove }) =>
           <div key={user.id}>
             <img src={user.profileImageUrl} alt={user.name} />
             <p>{user.name}</p>
-            <SubmitButton onClick={() => handleApproveClick(user.id)}>가입받기</SubmitButton>
+            <ButtonUnit mode="confirm" onClick={() => handleApproveClick(user.id)}>
+              가입받기
+            </ButtonUnit>
           </div>
         ))}
       </div>
@@ -60,8 +73,9 @@ const ClubRequest: React.FC<ClubRequestProps> = ({ pendingUsers, onApprove }) =>
         title="정말 이 회원을 가입받으시겠습니까?"
         confirmText="승인"
         cancelText="거절"
-        onConfirm={handleConfirm}
-        onCancel={() => setIsModalOpen(false)}
+        onConfirm={handleConfirm} // ✅ 승인
+        onCancel={handleReject} // ✅ 거절 처리 (상위 API 호출 가능)
+        onClose={closeModal} // ✅ 단순 닫기 (X, ESC)
       />
     </div>
   );

--- a/src/features/user/hooks/useUser.ts
+++ b/src/features/user/hooks/useUser.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 // 로그인
 export const loginUser = async (userId: string, password: string) => {
-  const res = await axios.post('/members/login', {
+  const res = await axios.post('/auth/login', {
     user_id: userId,
     password,
   });
@@ -21,7 +21,7 @@ export const joinUser = async ({
   email: string;
   password: string;
 }) => {
-  const res = await axios.post('/members/join', {
+  const res = await axios.post('/auth/join', {
     user_id: userId,
     nickname,
     email,
@@ -32,7 +32,7 @@ export const joinUser = async ({
 
 // 아이디 중복 확인
 export const checkUserIdDuplicate = async (userId: string) => {
-  const res = await axios.get(`/members/check-id`, {
+  const res = await axios.get(`/auth/check-id`, {
     params: { userId },
   });
   return !res.data.exists;
@@ -40,7 +40,7 @@ export const checkUserIdDuplicate = async (userId: string) => {
 
 // 이메일 중복 확인
 export const checkEmailDuplicate = async (email: string) => {
-  const res = await axios.get(`/members/check-email`, {
+  const res = await axios.get(`/auth/check-email`, {
     params: { email },
   });
   return !res.data.exists;
@@ -48,7 +48,7 @@ export const checkEmailDuplicate = async (email: string) => {
 
 // 현재 로그인된 사용자 정보 가져오기
 export const getMyInfo = async () => {
-  const res = await axios.get('/members/profile');
+  const res = await axios.get('/auth/profile');
   return res.data;
 };
 
@@ -59,12 +59,12 @@ export const updateMyInfo = async (data: {
   region?: string;
   interests?: string[];
 }) => {
-  const res = await axios.patch('/members/profile', data);
+  const res = await axios.patch('/auth/profile', data);
   return res.data;
 };
 
 // 로그아웃
 export const logoutUser = async () => {
-  const res = await axios.post('/members/logout');
+  const res = await axios.post('/auth/logout');
   return res.data;
 };

--- a/stories/BaseList.stories.tsx
+++ b/stories/BaseList.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import BaseList from '../src/common/components/ui/BaseList';
-import { MemoryRouter } from 'react-router-dom';
 
 // 기본 mock 데이터
 const sampleItems = [
@@ -15,9 +14,7 @@ const meta: Meta<typeof BaseList> = {
   decorators: [
     (Story) => (
       // useNavigate 대응을 위해 Router Provider 필요
-      <MemoryRouter>
-        <Story />
-      </MemoryRouter>
+      <Story />
     ),
   ],
   tags: ['autodocs'],

--- a/stories/ClubForm.stories.tsx
+++ b/stories/ClubForm.stories.tsx
@@ -31,10 +31,18 @@ const sampleMembers = [
   },
 ];
 
+// ✅ 공통 업로드 함수 정의 (스토리북용 mock 처리)
+const mockImageUpload = async (file: File): Promise<string> => {
+  console.log('스토리북 이미지 업로드 파일:', file);
+  // 실제 업로드 대신 가짜 URL 반환
+  return Promise.resolve('https://via.placeholder.com/300x150?text=UploadedImage');
+};
+
 export const CreateMode: Story = {
   args: {
     mode: 'create',
     onSubmit: (data) => alert(`제출 데이터: ${JSON.stringify(data, null, 2)}`),
+    onImageUpload: mockImageUpload,
   },
 };
 
@@ -49,5 +57,6 @@ export const EditMode: Story = {
       members: sampleMembers,
     },
     onSubmit: (data) => alert(`수정된 데이터: ${JSON.stringify(data, null, 2)}`),
+    onImageUpload: mockImageUpload,
   },
 };

--- a/stories/ClubList.stories.tsx
+++ b/stories/ClubList.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ClubList from '../src/features/club/components/ClubList';
+
+const meta: Meta<typeof ClubList> = {
+  title: 'Club/ClubList',
+  component: ClubList,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ClubList>;
+
+// ✅ 샘플 mock 데이터
+const sampleClubs = [
+  {
+    id: 'club1',
+    name: '하빗 러닝 클럽',
+    imageUrl: 'https://via.placeholder.com/100x100?text=Running',
+  },
+  {
+    id: 'club2',
+    name: '개발자 스터디',
+    imageUrl: 'https://via.placeholder.com/100x100?text=Dev',
+  },
+];
+
+// ✅ 기본 스토리
+export const Default: Story = {
+  args: {
+    items: sampleClubs,
+  },
+};
+
+// ✅ 빈 리스트 테스트용
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};

--- a/stories/ClubRequest.stories.tsx
+++ b/stories/ClubRequest.stories.tsx
@@ -10,6 +10,7 @@ const meta: Meta<typeof ClubRequest> = {
 export default meta;
 type Story = StoryObj<typeof ClubRequest>;
 
+// ✅ 샘플 유저 데이터
 const sampleUsers = [
   {
     id: 'user1',
@@ -23,9 +24,11 @@ const sampleUsers = [
   },
 ];
 
+// ✅ 기본 스토리 (승인 + 거절 둘 다 확인 가능)
 export const Default: Story = {
   args: {
     pendingUsers: sampleUsers,
-    onApprove: (userId) => alert(`가입 승인됨: ${userId}`),
+    onApprove: (userId) => alert(`✅ 가입 승인됨: ${userId}`),
+    onReject: (userId) => alert(`❌ 가입 거절됨: ${userId}`), // ✅ 거절 콜백 추가
   },
 };

--- a/stories/Modal.stories.tsx
+++ b/stories/Modal.stories.tsx
@@ -23,14 +23,21 @@ const meta: Meta<typeof Modal> = {
 export default meta;
 type Story = StoryObj<typeof Modal>;
 
-// ✅ 공통 템플릿
+// ✅ 공통 템플릿 (onClose 추가됨)
 const Template = (args: any) => {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <Modal
       {...args}
       isOpen={isOpen}
-      onCancel={() => setIsOpen(false)}
+      onCancel={() => {
+        alert('❌ 취소(거절) 동작');
+        setIsOpen(false);
+      }}
+      onClose={() => {
+        alert('🛑 닫기(X 또는 ESC)');
+        setIsOpen(false);
+      }}
       onConfirm={(data) => {
         alert(JSON.stringify(data, null, 2));
         setIsOpen(false);


### PR DESCRIPTION
클럽 관련 주요 기능을 개선하고, 공통 컴포넌트의 구조를 정비하였으며, Storybook 문서화 및 테스트 스토리를 업데이트했습니다.

### ✨ 주요 변경 사항

#### 🏷 Club 관련 기능 추가 및 개선
- `ClubForm` 컴포넌트
  - 이미지 업로드 기능 추가 (`onImageUpload` 콜백 처리)
  - 생성/수정 모드 분리 (`mode`, `initialData` 활용)
  - 내부 상태 정리 및 이미지 클릭 업로드 구조 적용
- `ClubRequest` 컴포넌트
  - `onReject` 콜백 추가로 거절 기능 확장
  - `SubmitButton` → `ButtonUnit`으로 통일
- `ClubList` 컴포넌트 및 Storybook 구성

#### 🧱 공통 컴포넌트 개선
- `Modal` 컴포넌트
  - `onClose` 핸들러 분리 (닫기 버튼, ESC 키 대응)
  - 관련 스토리에 설명 주석 및 예시 추가

#### 📚 Storybook 구성 개선
- ClubForm, ClubRequest, Modal 등 주요 컴포넌트에 JSDoc 기반 설명 추가
- 각 스토리에 args/argTypes 설정 및 mock 처리 개선

#### 🔁 내부 리팩토링
- `BaseList` 스토리에서 불필요한 `MemoryRouter` 제거
- `ClubForm` 이미지 업로드 처리 방식 및 상태 로직 정리
- 라우터 스타일 전역 적용 (`set:` 커밋)

#### 🌐 API 구조 수정
- 회원 관련 엔드포인트를 `/members` → `/auth`로 정리

