### PR TITLE
Feature/club/pages

### DIFF
--- a/src/common/api/imageApi.ts
+++ b/src/common/api/imageApi.ts
@@ -19,8 +19,8 @@ const uploadImage = async (file: File): Promise<string> => {
     });
 
     // 서버에서 반환한 성공 메시지
-    if (response.data.message === '이미지 업로드 성공') {
-      return response.data.message; // 성공 메시지 반환
+    if (typeof response.data.id === 'number') {
+      return response.data.id; // 성공 메시지 반환
     }
 
     throw new Error('이미지 업로드 실패');

--- a/src/common/components/ui/hooks/checkboxSelectionSlice.ts
+++ b/src/common/components/ui/hooks/checkboxSelectionSlice.ts
@@ -1,22 +1,27 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface CheckboxSelectionSlice {
-  selectedItems: string[];
+  interests: string[];
+  regions: string[];
 }
 
 const initialState: CheckboxSelectionSlice = {
-  selectedItems: [],
+  interests: [],
+  regions: [],
 };
 
 const checkboxSelectionSlice = createSlice({
   name: 'checkboxSelection',
   initialState,
   reducers: {
-    setSelectedItems(state, action: PayloadAction<string[]>) {
-      state.selectedItems = action.payload;
+    setInterests(state, action: PayloadAction<string[]>) {
+      state.interests = action.payload;
+    },
+    setRegions(state, action: PayloadAction<string[]>) {
+      state.regions = action.payload;
     },
   },
 });
 
-export const { setSelectedItems } = checkboxSelectionSlice.actions;
+export const { setInterests, setRegions } = checkboxSelectionSlice.actions;
 export default checkboxSelectionSlice.reducer;

--- a/src/common/layout/Sidebar.tsx
+++ b/src/common/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 // src/components/layout/Sidebar.tsx
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import Login from '../../features/user/components/Login';
 import InterestModal from '../components/utils/InterestModal';
@@ -10,6 +10,7 @@ import styled from '@emotion/styled';
 import { fc, flexStyle, jb, sectionStyle } from '../style/common.css';
 import { layoutTheme } from './layoutStyle.css';
 import ButtonUnit from '../components/ui/Buttons';
+import { setInterests, setRegions } from '../components/ui/hooks/checkboxSelectionSlice';
 
 const Sidebar: React.FC = () => {
   const userState = useSelector((state: RootState) => state.user);
@@ -18,8 +19,8 @@ const Sidebar: React.FC = () => {
   const [isRegionOpen, setRegionOpen] = useState(false);
   const [isLoginOpen, setLoginOpen] = useState(false);
 
-  const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
-  const [selectedRegions, setSelectedRegions] = useState<string[]>([]);
+  const dispatch = useDispatch();
+  const { interests, regions } = useSelector((state: RootState) => state.checkboxSelection);
 
   return (
     <AsideStyle>
@@ -67,16 +68,16 @@ const Sidebar: React.FC = () => {
       {/* 관심사 모달 */}
       <InterestModal
         isOpen={isInterestOpen}
-        selected={selectedInterests}
-        onChange={setSelectedInterests}
+        selected={interests}
+        onChange={(items) => dispatch(setInterests(items))}
         onClose={() => setInterestOpen(false)}
       />
 
       {/* 지역 모달 */}
       <RegionModal
         isOpen={isRegionOpen}
-        selected={selectedRegions}
-        onChange={setSelectedRegions}
+        selected={regions}
+        onChange={(items) => dispatch(setRegions(items))}
         onClose={() => setRegionOpen(false)}
       />
 

--- a/src/features/club/api/clubApi.ts
+++ b/src/features/club/api/clubApi.ts
@@ -97,7 +97,9 @@ export const fetchClubList = async (
   const response = await axios.get(`/api/clubs?category=${category}&region=${region}`);
   return response.data.clubs;
 };
-// clubApi.ts
+/**
+ * 모임 삭제
+ */
 export const deleteClub = async (clubId: number): Promise<string> => {
   const response = await axios.delete(`/api/clubs/${clubId}`);
   return response.data.message;

--- a/src/features/club/api/clubApi.ts
+++ b/src/features/club/api/clubApi.ts
@@ -8,6 +8,7 @@ export const createClub = async (data: {
   description: string;
   category: string;
   region: string;
+  imgId: number;
 }): Promise<number> => {
   const response = await axios.post('/api/clubs', data);
   return response.data.club_id;
@@ -23,6 +24,7 @@ export const fetchClubDetail = async (
   description: string;
   category: string;
   region: string;
+  imageUrl: string;
 }> => {
   const response = await axios.get(`/api/clubs/${clubId}`);
   return response.data;
@@ -36,6 +38,8 @@ export const updateClub = async (
   data: {
     description: string;
     category: string;
+    region: string;
+    imgId: number;
   },
 ): Promise<string> => {
   const response = await axios.put(`/api/clubs/${clubId}`, data);
@@ -66,7 +70,7 @@ export const fetchClubMembers = async (
   }[]
 > => {
   const response = await axios.get(`/api/clubs/${clubId}/members`);
-  return response.data.members;
+  return response.data.members ?? [];
 };
 
 /**
@@ -92,4 +96,9 @@ export const fetchClubList = async (
 > => {
   const response = await axios.get(`/api/clubs?category=${category}&region=${region}`);
   return response.data.clubs;
+};
+// clubApi.ts
+export const deleteClub = async (clubId: number): Promise<string> => {
+  const response = await axios.delete(`/api/clubs/${clubId}`);
+  return response.data.message;
 };

--- a/src/features/club/components/ClubRequest.tsx
+++ b/src/features/club/components/ClubRequest.tsx
@@ -24,10 +24,19 @@ interface ClubRequestProps {
   onReject?: (userId: string) => void;
   isAdmin?: boolean;
 }
-
 /**
  * ClubRequest 컴포넌트
- * 클럽 가입 요청자 목록을 표시하고, 운영자인 경우 가입 승인 버튼 제공
+ *
+ * 클럽 가입 요청자 목록을 표시하고 가입 수락/거절을 위한 모달을 띄운다.
+ * - 상위 컴포넌트에서 pendingUsers를 전달받아 렌더링함
+ * - 각 유저 항목에는 가입 수락 버튼이 존재하고, 클릭 시 확인 모달이 표시됨
+ * - 모달에서 '승인' 시 onApprove 콜백으로 유저 ID를 상위에 전달
+ * - '거절' 시 onReject 콜백으로 유저 ID를 상위에 전달
+ * - 닫기(X) 또는 ESC 키는 단순히 모달만 닫힘
+ *
+ * @component
+ * @param {ClubRequestProps} props - 가입 대기자 리스트와 승인/거절 콜백
+ * @returns {JSX.Element} 가입 요청자 리스트 UI
  */
 const ClubRequest: React.FC<ClubRequestProps> = ({
   pendingUsers,

--- a/src/features/club/components/ClubRequest.tsx
+++ b/src/features/club/components/ClubRequest.tsx
@@ -2,51 +2,70 @@ import React, { useState } from 'react';
 import Modal from '../../../common/components/ui/Modal';
 import ButtonUnit from '../../../common/components/ui/Buttons';
 
+/**
+ * 클럽 가입 요청 유저 정보를 나타내는 인터페이스
+ */
 interface ClubMember {
   id: string;
   name: string;
   profileImageUrl: string;
 }
 
+/**
+ * ClubRequest 컴포넌트 Props
+ * @property pendingUsers - 가입 대기 중인 유저 리스트
+ * @property onApprove - 유저 가입 승인 콜백
+ * @property onReject - 유저 가입 거절 콜백 (선택)
+ * @property isAdmin - 현재 로그인 유저가 운영자인지 여부 (기본값: false)
+ */
 interface ClubRequestProps {
   pendingUsers: ClubMember[];
   onApprove: (userId: string) => void;
-  onReject?: (userId: string) => void; // ✅ 거절 콜백 추가
+  onReject?: (userId: string) => void;
+  isAdmin?: boolean;
 }
 
 /**
  * ClubRequest 컴포넌트
- *
- * 클럽 가입 요청자 목록을 표시하고 가입 수락/거절을 위한 모달을 띄운다.
- * - 상위 컴포넌트에서 pendingUsers를 전달받아 렌더링함
- * - 각 유저 항목에는 가입 수락 버튼이 존재하고, 클릭 시 확인 모달이 표시됨
- * - 모달에서 '승인' 시 onApprove 콜백으로 유저 ID를 상위에 전달
- * - '거절' 시 onReject 콜백으로 유저 ID를 상위에 전달
- * - 닫기(X) 또는 ESC 키는 단순히 모달만 닫힘
- *
- * @component
- * @param {ClubRequestProps} props - 가입 대기자 리스트와 승인/거절 콜백
- * @returns {JSX.Element} 가입 요청자 리스트 UI
+ * 클럽 가입 요청자 목록을 표시하고, 운영자인 경우 가입 승인 버튼 제공
  */
-const ClubRequest: React.FC<ClubRequestProps> = ({ pendingUsers, onApprove, onReject }) => {
+const ClubRequest: React.FC<ClubRequestProps> = ({
+  pendingUsers,
+  onApprove,
+  onReject,
+  isAdmin = false,
+}) => {
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  /**
+   * 가입 승인 버튼 클릭 시 모달 열기
+   * @param userId - 선택된 유저 ID
+   */
   const handleApproveClick = (userId: string) => {
     setSelectedUserId(userId);
     setIsModalOpen(true);
   };
 
+  /**
+   * 모달 확인 클릭 시 승인 처리
+   */
   const handleConfirm = () => {
     if (selectedUserId) onApprove(selectedUserId);
     closeModal();
   };
 
+  /**
+   * 모달 취소 클릭 시 거절 처리
+   */
   const handleReject = () => {
     if (selectedUserId && onReject) onReject(selectedUserId);
     closeModal();
   };
 
+  /**
+   * 모달 닫기
+   */
   const closeModal = () => {
     setIsModalOpen(false);
     setSelectedUserId(null);
@@ -60,9 +79,13 @@ const ClubRequest: React.FC<ClubRequestProps> = ({ pendingUsers, onApprove, onRe
           <div key={user.id}>
             <img src={user.profileImageUrl} alt={user.name} />
             <p>{user.name}</p>
-            <ButtonUnit mode="confirm" onClick={() => handleApproveClick(user.id)}>
-              가입받기
-            </ButtonUnit>
+
+            {/* 운영자일 때만 가입받기 버튼 표시 */}
+            {isAdmin && (
+              <ButtonUnit mode="confirm" onClick={() => handleApproveClick(user.id)}>
+                가입받기
+              </ButtonUnit>
+            )}
           </div>
         ))}
       </div>
@@ -73,9 +96,9 @@ const ClubRequest: React.FC<ClubRequestProps> = ({ pendingUsers, onApprove, onRe
         title="정말 이 회원을 가입받으시겠습니까?"
         confirmText="승인"
         cancelText="거절"
-        onConfirm={handleConfirm} // ✅ 승인
-        onCancel={handleReject} // ✅ 거절 처리 (상위 API 호출 가능)
-        onClose={closeModal} // ✅ 단순 닫기 (X, ESC)
+        onConfirm={handleConfirm}
+        onCancel={handleReject}
+        onClose={closeModal}
       />
     </div>
   );

--- a/src/features/club/hooks/useClub.ts
+++ b/src/features/club/hooks/useClub.ts
@@ -56,10 +56,21 @@ export const useClubForm = (
     setError(null);
     try {
       if (mode === 'create') {
-        const newClubId = await createClub({ name, description, category, region });
+        const newClubId = await createClub({
+          name,
+          description,
+          category,
+          region,
+          imgId: 0,
+        });
         return newClubId;
       } else if (mode === 'edit' && clubId) {
-        const message = await updateClub(clubId, { description, category });
+        const message = await updateClub(clubId, {
+          description,
+          category,
+          region,
+          imgId: 0,
+        });
         return message;
       }
     } catch (e: any) {

--- a/src/features/club/pages/ClubDetailPage.tsx
+++ b/src/features/club/pages/ClubDetailPage.tsx
@@ -1,7 +1,173 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../store';
+import ClubDetail from '../components/ClubDetail';
+import ClubRequest from '../components/ClubRequest';
+import ButtonUnit from '../../../common/components/ui/Buttons';
+import {
+  fetchClubDetail,
+  fetchClubMembers,
+  requestJoinClub,
+  manageClubMember,
+} from '../api/clubApi';
 
-function ClubDetailPage() {
-  return <div>ClubDetailPage</div>;
+interface ClubMember {
+  id: string;
+  name: string;
+  profileImageUrl: string;
 }
+/**
+ * ClubDetailPage 컴포넌트
+ *
+ * 클럽 상세 페이지로, 다음의 기능을 포함한다:
+ *
+ * - 클럽 정보(fetchClubDetail) 및 멤버 목록(fetchClubMembers) 조회
+ * - 운영자(admin), 멤버(member), 가입대기자(pending) 구분하여 렌더링
+ * - 사용자가 클럽에 가입 요청을 보낼 수 있는 '가입하기' 버튼 제공
+ * - 운영자인 경우 가입대기자의 가입을 승인하거나 거절할 수 있는 기능 포함
+ *
+ * 상태 설명:
+ * @state name - 클럽 이름
+ * @state description - 클럽 소개
+ * @state imageUrl - 클럽 이미지 URL
+ * @state admins - 운영진 목록 (ClubMember[])
+ * @state members - 일반 멤버 목록 (ClubMember[])
+ * @state pendingUsers - 가입대기자 목록 (ClubMember[])
+ * @state hasJoined - 현재 로그인 유저가 해당 클럽에 가입되어 있는지 여부
+ * @state isAdmin - 현재 로그인 유저가 해당 클럽의 운영자인지 여부
+ *
+ * API 사용:
+ * - fetchClubDetail(clubId): 클럽 상세 정보 조회
+ * - fetchClubMembers(clubId): 멤버/운영진/대기자 목록 조회
+ * - requestJoinClub(clubId): 클럽 가입 요청
+ * - manageClubMember(clubId, { target_member_id, action }): 가입 승인/거절 처리
+ *
+ * 컴포넌트 렌더링 구성:
+ * 1. <ButtonUnit mode="cancel"> - 상단 뒤로가기 버튼
+ * 2. <ClubDetail> - 클럽 이미지, 이름, 소개, 운영진/멤버 리스트 렌더링
+ * 3. <ButtonUnit mode="confirm"> - 미가입 & 로그인 유저에게만 보이는 '가입하기' 버튼
+ * 4. <ClubRequest> - 운영자일 경우 가입 요청 대기자 목록 및 승인/거절 버튼 표시
+ */
+
+const ClubDetailPage: React.FC = () => {
+  const { clubId } = useParams<{ clubId: string }>();
+  const user = useSelector((state: RootState) => state.user);
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [admins, setAdmins] = useState<ClubMember[]>([]);
+  const [members, setMembers] = useState<ClubMember[]>([]);
+  const [pendingUsers, setPendingUsers] = useState<ClubMember[]>([]);
+  const [hasJoined, setHasJoined] = useState<boolean>(false);
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+  const defaultProfile = '/assets/default-profile.png';
+
+  useEffect(() => {
+    if (!clubId) return;
+
+    const fetchData = async () => {
+      try {
+        const detail = await fetchClubDetail(Number(clubId));
+        setName(detail.name);
+        setDescription(detail.description);
+        setImageUrl(detail.imageUrl);
+
+        const rawMembers = await fetchClubMembers(Number(clubId));
+
+        const admins: ClubMember[] = [];
+        const members: ClubMember[] = [];
+        const pending: ClubMember[] = [];
+
+        rawMembers.forEach((m) => {
+          const mapped: ClubMember = {
+            id: m.member_id.toString(),
+            name: m.nickname,
+            profileImageUrl: defaultProfile,
+          };
+
+          if (m.role === 'admin') {
+            admins.push(mapped);
+            if (m.member_id.toString() === user.userId) {
+              setIsAdmin(true);
+              setHasJoined(true);
+            }
+          } else if (m.role === 'member') {
+            members.push(mapped);
+            if (m.member_id.toString() === user.userId) {
+              setHasJoined(true);
+            }
+          } else if (m.role === 'pending') {
+            pending.push(mapped);
+            if (m.member_id.toString() === user.userId) {
+              setHasJoined(true);
+            }
+          }
+        });
+
+        setAdmins(admins);
+        setMembers(members);
+        setPendingUsers(pending);
+      } catch (err) {
+        alert('클럽 정보를 불러오지 못했습니다.' + err);
+      }
+    };
+
+    fetchData();
+  }, [clubId, user.userId]);
+
+  const handleJoin = async () => {
+    if (!clubId) return;
+    try {
+      await requestJoinClub(Number(clubId));
+      alert('가입 요청이 전송되었습니다.');
+      setHasJoined(true);
+    } catch (err) {
+      alert('가입 요청에 실패했습니다.');
+    }
+  };
+
+  const handleApprove = (userId: string) => {
+    if (!clubId) return;
+    manageClubMember(Number(clubId), { target_member_id: Number(userId), action: 'approve' })
+      .then(() => window.location.reload())
+      .catch(() => alert('승인 실패'));
+  };
+
+  const handleReject = (userId: string) => {
+    if (!clubId) return;
+    manageClubMember(Number(clubId), { target_member_id: Number(userId), action: 'reject' })
+      .then(() => window.location.reload())
+      .catch(() => alert('거절 실패'));
+  };
+
+  return (
+    <div>
+      <ButtonUnit mode="cancel">뒤로가기</ButtonUnit>
+
+      <ClubDetail
+        imageUrl={imageUrl}
+        name={name}
+        description={description}
+        admins={admins}
+        members={members}
+      />
+
+      {!hasJoined && user.isLogin && (
+        <ButtonUnit mode="confirm" onClick={handleJoin}>
+          가입하기
+        </ButtonUnit>
+      )}
+
+      <ClubRequest
+        pendingUsers={pendingUsers}
+        onApprove={handleApprove}
+        onReject={handleReject}
+        isAdmin={isAdmin}
+      />
+    </div>
+  );
+};
 
 export default ClubDetailPage;

--- a/src/features/club/pages/ClubListPage.tsx
+++ b/src/features/club/pages/ClubListPage.tsx
@@ -1,7 +1,62 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../store';
+import { fetchClubList } from '../api/clubApi';
+import ClubList from '../components/ClubList';
+import ButtonUnit from '../../../common/components/ui/Buttons';
+/**
+ * ClubListPage 컴포넌트
+ *
+ * 관심사 및 지역 필터에 기반하여 클럽 목록을 불러와 화면에 렌더링한다.
+ * 클럽 목록은 Redux 상태에서 선택된 필터 조건(interests, regions)을 기준으로 API 요청을 보내며,
+ * 리스트는 카드 형태로 렌더링되고, 하단에 더보기 버튼이 위치함 (현재 더보기 기능은 미구현).
+ *
+ * 상태 설명:
+ * @state clubs - 렌더링할 클럽 카드 리스트 배열 (id, name, imageUrl 포함)
+ *
+ * 외부 상태:
+ * @redux checkboxSelection - Redux 전역 상태에서 관심사(interests), 지역(regions) 필터 값을 사용
+ *
+ * API 사용:
+ * - fetchClubList(category: string, region: string): 클럽 리스트를 필터 조건(category, region) 기준으로 조회
+ *
+ * 컴포넌트 구성:
+ * 1. <h2> - 페이지 제목
+ * 2. <ClubList> - 클럽 카드 리스트 컴포넌트, props로 clubs 배열과 routePrefix 전달
+ * 3. <ButtonUnit mode="more"> - 하단 '더보기' 버튼 (현재는 기능 없음, UI 위치용으로만 존재)
+ */
 
-function ClubListPage() {
-  return <div>ClubListPage</div>;
-}
+const ClubListPage: React.FC = () => {
+  const { interests, regions } = useSelector((state: RootState) => state.checkboxSelection);
+
+  const [clubs, setClubs] = useState<{ id: string; name: string; imageUrl: string }[]>([]);
+
+  useEffect(() => {
+    const category = interests[0] || '전체';
+    const region = regions[0] || '전체';
+
+    fetchClubList(category, region).then((data) => {
+      const mapped = data.map((club) => ({
+        id: club.club_id.toString(),
+        name: club.name,
+        imageUrl: '/placeholder.png', // TODO: imageUrl 서버 응답에 따라 교체
+      }));
+      setClubs(mapped);
+    });
+  }, [interests, regions]);
+
+  return (
+    <div>
+      <h2>모임 리스트</h2>
+      <ClubList items={clubs} routePrefix="/club" />
+      {/* 더보기 버튼 - 기능 없음, 위치용 */}
+      <div style={{ display: 'flex', justifyContent: 'center', marginTop: '2rem' }}>
+        <ButtonUnit mode="more" onClick={() => {}}>
+          더보기
+        </ButtonUnit>
+      </div>
+    </div>
+  );
+};
 
 export default ClubListPage;

--- a/src/features/club/pages/ClubModifyPage.tsx
+++ b/src/features/club/pages/ClubModifyPage.tsx
@@ -1,7 +1,193 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { fetchClubDetail, fetchClubMembers, updateClub, deleteClub } from '../api/clubApi';
+import ClubForm from '../components/ClubForm';
+import ButtonUnit from '../../../common/components/ui/Buttons';
+import uploadImage from '../../../common/api/imageApi';
+import Modal from '../../../common/components/ui/Modal';
+import { INTERESTS } from '../../../constants/interests';
+import { REGIONS } from '../../../constants/regions';
 
-function ClubModifyPage() {
-  return <div>ClubModifyPage</div>;
+interface ClubMember {
+  id: string;
+  name: string;
+  profileImageUrl: string;
 }
+/**
+ * ClubModifyPage 컴포넌트
+ *
+ * 클럽 정보 수정 페이지로, 기존 클럽의 상세 정보를 불러와 수정할 수 있는 기능을 제공한다.
+ *
+ * 주요 기능:
+ * - 클럽 상세 정보 및 멤버 목록 불러오기 (운영자, 일반 멤버 구분)
+ * - 클럽 이름, 소개, 이미지 수정
+ * - 관심사 및 지역 설정 (모달 기반)
+ * - 클럽 삭제
+ *
+ * 상태 설명:
+ * @state initialData - 클럽 초기 데이터 (name, description, imageUrl, adims, members)
+ * @state category - 현재 설정된 클럽 관심사 (단일 선택)
+ * @state region - 현재 설정된 클럽 지역 (단일 선택)
+ * @state isInterestOpen - 관심사 모달 오픈 여부
+ * @state isRegionOpen - 지역 모달 오픈 여부
+ *
+ * API 사용:
+ * - fetchClubDetail(clubId): 클럽 상세 정보 조회
+ * - fetchClubMembers(clubId): 클럽 멤버 목록 조회
+ * - updateClub(clubId, data): 클럽 수정 API
+ * - deleteClub(clubId): 클럽 삭제 API
+ * - uploadImage(file): 이미지 업로드 후 imgId 반환
+ *
+ * UI 구성:
+ * 1. 상단 X 버튼 → 뒤로가기 (`ButtonUnit mode="cancel"`)
+ * 2. 관심사/지역 설정 버튼 → 모달 열기
+ * 3. <ClubForm> → 이름, 소개, 이미지 등 수정 입력
+ * 4. 하단 "모임 삭제" 버튼
+ * 5. <Modal> → 관심사/지역 설정 모달 (단일 선택 방식)
+ */
+
+const ClubModifyPage: React.FC = () => {
+  const { clubId } = useParams<{ clubId: string }>();
+  const navigate = useNavigate();
+  const [initialData, setInitialData] = useState<{
+    name: string;
+    description: string;
+    imageUrl: string;
+    adims: ClubMember[];
+    members: ClubMember[];
+  } | null>(null);
+
+  const [category, setCategory] = useState<string>('');
+  const [region, setRegion] = useState<string>('');
+  const [isInterestOpen, setInterestOpen] = useState(false);
+  const [isRegionOpen, setRegionOpen] = useState(false);
+
+  useEffect(() => {
+    if (!clubId) return;
+
+    const fetchData = async () => {
+      try {
+        const detail = await fetchClubDetail(Number(clubId));
+        const membersData = await fetchClubMembers(Number(clubId));
+
+        const adims = membersData
+          .filter((m) => m.role === 'admin')
+          .map((m) => ({
+            id: m.member_id.toString(),
+            name: m.nickname,
+            profileImageUrl: '/assets/default-profile.png',
+          }));
+
+        const members = membersData
+          .filter((m) => m.role === 'member')
+          .map((m) => ({
+            id: m.member_id.toString(),
+            name: m.nickname,
+            profileImageUrl: '/assets/default-profile.png',
+          }));
+
+        setInitialData({
+          name: detail.name,
+          description: detail.description,
+          imageUrl: detail.imageUrl,
+          adims,
+          members,
+        });
+
+        setCategory(detail.category);
+        setRegion(detail.region);
+      } catch (err) {
+        alert('클럽 정보를 불러오지 못했습니다.');
+      }
+    };
+
+    fetchData();
+  }, [clubId]);
+
+  const handleSubmit = async (data: { name: string; description: string; image: File | null }) => {
+    if (!clubId || !initialData) return;
+    try {
+      let imgId: number | undefined = undefined;
+
+      if (data.image) {
+        imgId = Number(await uploadImage(data.image));
+      }
+
+      await updateClub(Number(clubId), {
+        description: data.description,
+        category,
+        region,
+        imgId: imgId ?? 0,
+      });
+
+      alert('수정이 완료되었습니다.');
+    } catch (err) {
+      alert('수정에 실패했습니다.');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!clubId) return;
+    if (!window.confirm('정말로 이 모임을 삭제하시겠습니까?')) return;
+
+    try {
+      await deleteClub(Number(clubId));
+      alert('모임이 삭제되었습니다.');
+      navigate('/clubs');
+    } catch (err: any) {
+      const msg = err.response?.data?.error || '삭제에 실패했습니다.';
+      alert(msg);
+    }
+  };
+
+  if (!initialData) return <p>로딩중...</p>;
+
+  return (
+    <div>
+      {/* 상단 뒤로가기 버튼 */}
+      <div>
+        <ButtonUnit mode="cancel" children={'X'} />
+      </div>
+
+      <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
+        <ButtonUnit mode="base" onClick={() => setInterestOpen(true)}>
+          모임 카테고리 설정
+        </ButtonUnit>
+        <ButtonUnit mode="base" onClick={() => setRegionOpen(true)}>
+          지역 설정
+        </ButtonUnit>
+      </div>
+
+      <ClubForm mode="edit" initialData={initialData} onSubmit={handleSubmit} />
+
+      <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end' }}>
+        <ButtonUnit mode="cancel" onClick={handleDelete}>
+          모임 삭제
+        </ButtonUnit>
+      </div>
+
+      {/* 모달 영역 */}
+      <Modal
+        isOpen={isInterestOpen}
+        mode="checkbox"
+        title="관심사 설정"
+        checkboxItems={INTERESTS}
+        checked={[category]}
+        onCheckedChange={(items) => setCategory(items[0])}
+        onClose={() => setInterestOpen(false)}
+      />
+
+      <Modal
+        isOpen={isRegionOpen}
+        mode="checkbox"
+        title="지역 설정"
+        checkboxItems={REGIONS}
+        checked={[region]}
+        onCheckedChange={(items) => setRegion(items[0])}
+        onClose={() => setRegionOpen(false)}
+      />
+    </div>
+  );
+};
 
 export default ClubModifyPage;


### PR DESCRIPTION
### 📌 Club 페이지 기능 통합 및 개선 PR

클럽 생성/수정/조회 페이지 및 관련 컴포넌트를 통합적으로 구현하고, 기능별 리팩토링 및 주석 추가를 통해 유지보수성을 향상시켰습니다.

---

### ✅ 주요 변경 사항

#### 📁 기능 구현
- `ClubModifyPage` 컴포넌트 구현 및 클럽 정보 수정 기능 추가
- `ClubDetailPage` 컴포넌트 구현 및 클럽 정보/멤버 목록 조회 기능 추가
- `ClubListPage` 컴포넌트 구현 및 클럽 목록 API 연동
- `ClubRequest` 컴포넌트 구현 (가입 대기자 목록 및 승인/거절 기능)

#### 🔄 API 연동 및 구조 개선
- 클럽 API (`fetchClubDetail`, `updateClub`, `fetchClubMembers`)에 `imgId`, `imageUrl` 필드 추가
- 이미지 업로드 시 서버로부터 `imgId` 반환 받아 처리하도록 변경
- 체크박스 선택 슬라이스 상태 구조 변경 (`interests`, `regions` 분리)

#### 🎨 UI 개선 및 모달 연동
- `Sidebar`에서 관심사 및 지역 설정 모달 상태를 전역 관리로 전환
- 관심사 및 지역 설정을 위한 통합 `Modal` 컴포넌트 연동

#### 🧼 리팩토링 & 문서화
- 주요 함수 및 컴포넌트에 JSDoc 주석 추가
- 조건부 렌더링, props 분기 등 클린 코드 리팩토링 적용

---

### 📝 참고
- 클럽 생성/수정 시 `imgId`, `category`, `region` 필드가 포함되어야 합니다.
- 추후 '더보기' 페이지네이션 구현 예정입니다.
