### PR TITLE
Feature/myclubpage

### DIFF
--- a/src/features/user/components/Login.tsx
+++ b/src/features/user/components/Login.tsx
@@ -34,6 +34,7 @@ const Login: React.FC<LoginProps> = ({ isOpen, onClose }) => {
           userId: profile.user_id,
           nickname: profile.nickname,
           email: profile.email,
+          userProfile: profile.profile_media_id || null,
         }),
       );
       setApiError('');

--- a/src/features/user/components/MyJoinedClubList.tsx
+++ b/src/features/user/components/MyJoinedClubList.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import BaseList from '../../../common/components/ui/BaseList';
+import { Club } from '../types';
+
+interface MyJoinedClubListProps {
+  clubs: Club[];
+}
+
+/**
+ * MyJoinedClubList 컴포넌트
+ *
+ * 사용자가 참여 중인 모임(클럽) 목록을 렌더링하는 컴포넌트입니다.
+ * - BaseList를 사용하여 카드 형태로 표시합니다.
+ * - 항목 클릭 시 상세 페이지로 이동합니다.
+ *
+ * @param {Club[]} clubs - 참여 중인 모임 데이터 배열
+ * @returns {JSX.Element | null} 렌더링된 리스트 또는 null
+ */
+const MyJoinedClubList: React.FC<MyJoinedClubListProps> = ({ clubs }) => {
+  if (!clubs || clubs.length === 0) return null;
+
+  const items = clubs.map((club) => ({
+    id: club.id,
+    name: club.name,
+    imageUrl: club.imageUrl,
+  }));
+
+  return (
+    <section>
+      <h3>내가 참여한 모임</h3>
+      <BaseList items={items} routePrefix="/club" />
+    </section>
+  );
+};
+
+export default MyJoinedClubList;

--- a/src/features/user/components/MyJoinedThunderList.tsx
+++ b/src/features/user/components/MyJoinedThunderList.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import BaseList from '../../../common/components/ui/BaseList';
+import { Thunder } from '../types';
+
+interface MyJoinedThunderListProps {
+  thunders: Thunder[];
+}
+
+/**
+ * MyJoinedThunderList 컴포넌트
+ *
+ * 사용자가 참여 중인 번개 모임 목록을 렌더링하는 컴포넌트입니다.
+ * - BaseList를 사용하여 카드 형태로 표시합니다.
+ * - 항목 클릭 시 상세 페이지로 이동합니다.
+ *
+ * @param {Thunder[]} thunders - 참여 중인 번개 모임 데이터 배열
+ * @returns {JSX.Element | null} 렌더링된 리스트 또는 null
+ */
+const MyJoinedThunderList: React.FC<MyJoinedThunderListProps> = ({ thunders }) => {
+  if (!thunders || thunders.length === 0) return null;
+
+  const items = thunders.map((thunder) => ({
+    id: thunder.id,
+    name: thunder.name,
+    imageUrl: thunder.imageUrl,
+  }));
+
+  return (
+    <section>
+      <h3>내가 참여한 번개모임</h3>
+      <BaseList items={items} routePrefix="/thunder" />
+    </section>
+  );
+};
+
+export default MyJoinedThunderList;

--- a/src/features/user/components/MyManagedClubList.tsx
+++ b/src/features/user/components/MyManagedClubList.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import BaseList from '../../../common/components/ui/BaseList';
+import { Club } from '../types';
+
+interface MyManagedClubListProps {
+  clubs: Club[];
+}
+
+/**
+ * MyManagedClubList 컴포넌트
+ *
+ * 사용자가 운영 중인 모임(클럽) 목록을 렌더링하는 컴포넌트입니다.
+ * - BaseList를 사용하여 카드 형태로 표시합니다.
+ * - BaseList 아래에 "모임 만들기" 버튼(카드 형식)을 별도로 렌더링합니다.
+ * - 항목 클릭 시 상세 페이지로 이동합니다.
+ *
+ * @param {Club[]} clubs - 운영 중인 모임 데이터 배열
+ * @returns {JSX.Element | null} 렌더링된 리스트 또는 null
+ */
+const MyManagedClubList: React.FC<MyManagedClubListProps> = ({ clubs }) => {
+  const navigate = useNavigate();
+
+  const items = clubs.map((club) => ({
+    id: club.id,
+    name: club.name,
+    imageUrl: club.imageUrl,
+  }));
+
+  return (
+    <section>
+      <h3>내가 운영 중인 모임</h3>
+      <BaseList items={items} routePrefix="/club" />
+
+      {/* 모임 만들기 카드 */}
+      <div
+        onClick={() => navigate('/club/create')}
+        style={{
+          border: '1px dashed #aaa',
+          padding: '20px',
+          textAlign: 'center',
+          marginTop: '12px',
+          cursor: 'pointer',
+        }}
+      >
+        + 모임 만들기
+      </div>
+    </section>
+  );
+};
+
+export default MyManagedClubList;

--- a/src/features/user/hooks/useMypage.ts
+++ b/src/features/user/hooks/useMypage.ts
@@ -1,38 +1,15 @@
 import axios from '../../../lib/axios';
+import { MyPageList } from '../types';
 
-export const fetchJoinedMyClubList = async (
-  id: string,
-): Promise<
-  {
-    club_id: number;
-    title: string;
-    imgUrl: string | null;
-  }[]
-> => {
+export const fetchJoinedMyClubList = async (id: string): Promise<MyPageList> => {
   const response = await axios.get(`/api/joinedclub/${id}`);
   return response.data.joinedMyClubs;
 };
-export const fetchMyClubList = async (
-  id: string,
-): Promise<
-  {
-    club_id: number;
-    title: string;
-    imgUrl: string | null;
-  }[]
-> => {
+export const fetchMyClubList = async (id: string): Promise<MyPageList> => {
   const response = await axios.get(`/api/myclub/${id}`);
   return response.data.MyClubs;
 };
-export const fetchJoinedMyThunderClubList = async (
-  id: string,
-): Promise<
-  {
-    club_id: number;
-    title: string;
-    imgUrl: string | null;
-  }[]
-> => {
+export const fetchJoinedMyThunderClubList = async (id: string): Promise<MyPageList> => {
   const response = await axios.get(`/api/joinedthunderclub/${id}`);
   return response.data.joinedMyThunders;
 };

--- a/src/features/user/hooks/useMypage.ts
+++ b/src/features/user/hooks/useMypage.ts
@@ -1,0 +1,38 @@
+import axios from '../../../lib/axios';
+
+export const fetchJoinedMyClubList = async (
+  id: string,
+): Promise<
+  {
+    club_id: number;
+    title: string;
+    imgUrl: string | null;
+  }[]
+> => {
+  const response = await axios.get(`/api/joinedclub/${id}`);
+  return response.data.joinedMyClubs;
+};
+export const fetchMyClubList = async (
+  id: string,
+): Promise<
+  {
+    club_id: number;
+    title: string;
+    imgUrl: string | null;
+  }[]
+> => {
+  const response = await axios.get(`/api/myclub/${id}`);
+  return response.data.MyClubs;
+};
+export const fetchJoinedMyThunderClubList = async (
+  id: string,
+): Promise<
+  {
+    club_id: number;
+    title: string;
+    imgUrl: string | null;
+  }[]
+> => {
+  const response = await axios.get(`/api/joinedthunderclub/${id}`);
+  return response.data.joinedMyThunders;
+};

--- a/src/features/user/hooks/userSlice.ts
+++ b/src/features/user/hooks/userSlice.ts
@@ -5,6 +5,7 @@ interface UserState {
   userId: string | null;
   nickname: string | null;
   email: string | null;
+  userProfile: string | null;
 }
 
 const initialState: UserState = {
@@ -12,6 +13,7 @@ const initialState: UserState = {
   userId: null,
   nickname: null,
   email: null,
+  userProfile: null,
 };
 
 const userSlice = createSlice({
@@ -20,18 +22,25 @@ const userSlice = createSlice({
   reducers: {
     loginSuccess: (
       state,
-      action: PayloadAction<{ userId: string; nickname: string; email: string }>,
+      action: PayloadAction<{
+        userId: string;
+        nickname: string;
+        email: string;
+        userProfile: string | null;
+      }>,
     ) => {
       state.isLogin = true;
       state.userId = action.payload.userId;
       state.nickname = action.payload.nickname;
       state.email = action.payload.email;
+      state.userProfile = action.payload.userProfile || null;
     },
     logout: (state) => {
       state.isLogin = false;
       state.userId = null;
       state.nickname = null;
       state.email = null;
+      state.userProfile = null;
     },
   },
 });

--- a/src/features/user/pages/MyClubPage.tsx
+++ b/src/features/user/pages/MyClubPage.tsx
@@ -27,21 +27,16 @@ import {
   fetchJoinedMyThunderClubList,
 } from '../../user/hooks/useMypage';
 import ButtonUnit from '../../../common/components/ui/Buttons';
+import { MyPageList } from '../types';
 
 const MyClubPage = () => {
   const userId = useAppSelector((state) => state.user.userId);
   const nickname = useAppSelector((state) => state.user.nickname);
   const profileUrl = useAppSelector((state) => state.user.userProfile);
 
-  const [joinedClubs, setJoinedClubs] = useState<
-    { club_id: number; title: string; imgUrl: string | null }[]
-  >([]);
-  const [managedClubs, setManagedClubs] = useState<
-    { club_id: number; title: string; imgUrl: string | null }[]
-  >([]);
-  const [joinedThunders, setJoinedThunders] = useState<
-    { club_id: number; title: string; imgUrl: string | null }[]
-  >([]);
+  const [joinedClubs, setJoinedClubs] = useState<MyPageList>([]);
+  const [managedClubs, setManagedClubs] = useState<MyPageList>([]);
+  const [joinedThunders, setJoinedThunders] = useState<MyPageList>([]);
 
   useEffect(() => {
     if (!userId) return;

--- a/src/features/user/pages/MyClubPage.tsx
+++ b/src/features/user/pages/MyClubPage.tsx
@@ -1,5 +1,100 @@
-function MyClubPage() {
-  return <div></div>;
-}
+/**
+ * MyClubPage 컴포넌트
+ *
+ * 사용자가 참여 중인 모임, 운영 중인 모임, 참여한 번개모임을 하나의 페이지에 통합하여 보여주는 페이지입니다.
+ *
+ * ✅ 기능
+ * - 상단에 사용자 프로필 이미지, 닉네임, 닫기 버튼(`ButtonUnit`)을 표시
+ * - 사용자 ID를 기반으로 API 요청을 통해 각 섹션의 데이터(fetchJoinedMyClubList, fetchMyClubList, fetchJoinedMyThunderClubList)를 불러옴
+ * - 참여한 모임은 `MyJoinedClubList`, 운영 중인 모임은 `MyManagedClubList`, 참여한 번개모임은 `MyJoinedThunderList` 컴포넌트로 각각 분리하여 렌더링
+ * - 닫기 버튼 클릭 시 `navigate(-1)`로 이전 페이지로 이동
+ *
+ * ✅ 사용된 상태
+ * - Redux에서 사용자 정보(userId, nickname, profileUrl)를 가져옴
+ * - useState로 각 섹션별 리스트 상태를 관리
+ *
+ * @returns {JSX.Element} 내 모임 정보를 보여주는 마이페이지 뷰
+ */
+
+import { useEffect, useState } from 'react';
+import { useAppSelector } from '../../../store/hook';
+import MyJoinedClubList from '../components/MyJoinedClubList';
+import MyManagedClubList from '../components/MyManagedClubList';
+import MyJoinedThunderList from '../components/MyJoinedThunderlist';
+import {
+  fetchJoinedMyClubList,
+  fetchMyClubList,
+  fetchJoinedMyThunderClubList,
+} from '../../user/hooks/useMypage';
+import ButtonUnit from '../../../common/components/ui/Buttons';
+
+const MyClubPage = () => {
+  const userId = useAppSelector((state) => state.user.userId);
+  const nickname = useAppSelector((state) => state.user.nickname);
+  const profileUrl = useAppSelector((state) => state.user.userProfile);
+
+  const [joinedClubs, setJoinedClubs] = useState<
+    { club_id: number; title: string; imgUrl: string | null }[]
+  >([]);
+  const [managedClubs, setManagedClubs] = useState<
+    { club_id: number; title: string; imgUrl: string | null }[]
+  >([]);
+  const [joinedThunders, setJoinedThunders] = useState<
+    { club_id: number; title: string; imgUrl: string | null }[]
+  >([]);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const fetchData = async () => {
+      try {
+        const clubs = await fetchJoinedMyClubList(userId);
+        const myClubs = await fetchMyClubList(userId);
+        const thunders = await fetchJoinedMyThunderClubList(userId);
+
+        setJoinedClubs(clubs);
+        setManagedClubs(myClubs);
+        setJoinedThunders(thunders);
+      } catch (error) {
+        console.error('내 모임 데이터 불러오기 실패:', error);
+      }
+    };
+
+    fetchData();
+  }, [userId]);
+
+  return (
+    <div>
+      {/* 사용자 정보 */}
+      <section
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '16px 0',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <img
+            src={profileUrl || '/assets/default-profile.png'}
+            alt="프로필 이미지"
+            style={{ width: '48px', height: '48px', borderRadius: '50%' }}
+          />
+          <span style={{ fontSize: '18px', fontWeight: 'bold' }}>{nickname}</span>
+        </div>
+        <ButtonUnit mode="cancel">✕</ButtonUnit>
+      </section>
+
+      {/* 내가 참여 중인 모임 */}
+      <MyJoinedClubList clubs={joinedClubs} />
+
+      {/* 내가 운영 중인 모임 */}
+      <MyManagedClubList clubs={managedClubs} />
+
+      {/* 내가 참여 중인 번개모임 */}
+      <MyJoinedThunderList thunders={joinedThunders} />
+    </div>
+  );
+};
 
 export default MyClubPage;

--- a/src/features/user/pages/MyClubPage.tsx
+++ b/src/features/user/pages/MyClubPage.tsx
@@ -27,16 +27,16 @@ import {
   fetchJoinedMyThunderClubList,
 } from '../../user/hooks/useMypage';
 import ButtonUnit from '../../../common/components/ui/Buttons';
-import { MyPageList } from '../types';
+import { JoinedClubList, JoinedThunderList, ManagedClubList } from '../types';
 
 const MyClubPage = () => {
   const userId = useAppSelector((state) => state.user.userId);
   const nickname = useAppSelector((state) => state.user.nickname);
   const profileUrl = useAppSelector((state) => state.user.userProfile);
 
-  const [joinedClubs, setJoinedClubs] = useState<MyPageList>([]);
-  const [managedClubs, setManagedClubs] = useState<MyPageList>([]);
-  const [joinedThunders, setJoinedThunders] = useState<MyPageList>([]);
+  const [joinedClubs, setJoinedClubs] = useState<JoinedClubList>([]);
+  const [managedClubs, setManagedClubs] = useState<ManagedClubList>([]);
+  const [joinedThunders, setJoinedThunders] = useState<JoinedThunderList>([]);
 
   useEffect(() => {
     if (!userId) return;

--- a/src/features/user/pages/MyClubPage.tsx
+++ b/src/features/user/pages/MyClubPage.tsx
@@ -20,7 +20,7 @@ import { useEffect, useState } from 'react';
 import { useAppSelector } from '../../../store/hook';
 import MyJoinedClubList from '../components/MyJoinedClubList';
 import MyManagedClubList from '../components/MyManagedClubList';
-import MyJoinedThunderList from '../components/MyJoinedThunderlist';
+import MyJoinedThunderList from '../components/MyJoinedThunderList';
 import {
   fetchJoinedMyClubList,
   fetchMyClubList,

--- a/src/features/user/types.ts
+++ b/src/features/user/types.ts
@@ -1,0 +1,6 @@
+export interface MyPageItem {
+  Club_id: number;
+  title: string;
+  imgUrl: string | null;
+}
+export type MyPageList = MyPageItem[];

--- a/src/features/user/types.ts
+++ b/src/features/user/types.ts
@@ -3,4 +3,29 @@ export interface MyPageItem {
   title: string;
   imgUrl: string | null;
 }
+
 export type MyPageList = MyPageItem[];
+
+export interface JoinedClubItem {
+  Club_id: number;
+  title: string;
+  imgUrl: string | null;
+}
+
+export type JoinedClubList = JoinedClubItem[];
+
+export interface ManagedClubItem {
+  Club_id: number;
+  title: string;
+  imgUrl: string | null;
+}
+
+export type ManagedClubList = ManagedClubItem[];
+
+export interface JoinedThunderItem {
+  Club_id: number;
+  title: string;
+  imgUrl: string | null;
+}
+
+export type JoinedThunderList = JoinedThunderItem[];


### PR DESCRIPTION
## ✅ 주요 변경 사항

### 🧩 기능 구현
- `MyClubPage` 페이지 구현
  - 사용자 프로필 이미지, 닉네임, 닫기 버튼 포함
  - 참여/운영 중인 클럽 리스트 및 번개모임 리스트 통합 표시
- `MyJoinedClubList`, `MyJoinedThunderList` 컴포넌트 생성
  - `BaseList` 기반으로 카드형 리스트 렌더링
- `MyManagedClubList`에서 `BaseList` 사용 + `모임 만들기` 버튼 별도 표시

### 🔄 API 연동
- `useMypage.ts` 추가
  - `fetchJoinedMyClubList`, `fetchMyClubList`, `fetchJoinedMyThunderClubList` API 함수 구현
  - 페이지 내에서 직접 호출하여 데이터 세팅

### 🧠 상태 연동
- Redux `user` 상태에서 사용자 ID, 닉네임, 프로필 이미지 참조

### 🎨 UI 요소
- 닫기 버튼은 공통 컴포넌트 `ButtonUnit`의 `mode="cancel"`로 처리

### 📚 문서화
- `MyClubPage` 및 주요 컴포넌트에 JSDoc 주석 추가

## 📝 테스트 방법
- `/myclub` 경로에서 사용자 로그인 상태로 진입 시:
  - 상단 사용자 정보가 표시되어야 함
  - 클럽, 번개모임 리스트가 정상적으로 표시되어야 함
  - `X` 버튼 클릭 시 이전 페이지로 이동
  - `+ 모임 만들기` 클릭 시 `/club/create`로 이동

